### PR TITLE
Optimisations, fixes, Neural Network Viewer

### DIFF
--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -127,7 +127,7 @@ namespace MaceEvolve.Controls
 
             List<Creature> NewCreatures = new List<Creature>();
 
-            Creature NewCreature = Creature.Reproduce(SuccessfulCreatures, PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList());
+            Creature NewCreature = Creature.Reproduce(SuccessfulCreatures.ToList(), PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList());
             NewCreature.GameHost = this;
             NewCreature.X = _Random.Next(WorldBounds.Left + WorldBounds.Width);
             NewCreature.Y = _Random.Next(WorldBounds.Top + WorldBounds.Height);
@@ -280,7 +280,7 @@ namespace MaceEvolve.Controls
             //Remove node before mutating them so that the mutations are not voided.
             if (NodeToRemove != null)
             {
-                Network.RemoveNode(NodeToRemove, true);
+                Network.RemoveNode(Network.NodesToNodeIdsDict[NodeToRemove], true);
             }
 
             //Mutate a random connection.

--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -54,11 +54,11 @@ namespace MaceEvolve.Controls
         public Rectangle WorldBounds { get; set; }
         public Rectangle SuccessBounds { get; set; }
         public int MinCreatureConnections { get; set; } = 4;
-        public int MaxCreatureConnections { get; set; } = 512;
+        public int MaxCreatureConnections { get; set; } = 128;
         public double CreatureSpeed { get; set; }
         public double NewGenerationInterval { get; set; } = 12;
         public double SecondsUntilNewGeneration { get; set; } = 12;
-        public int MaxCreatureProcessNodes { get; set; } = 8;
+        public int MaxCreatureProcessNodes { get; set; } = 4;
         public double MutationChance { get; set; } = 0.1;
         public double MutationAttempts { get; set; } = 10;
         public double ConnectionWeightBound { get; set; } = 4;
@@ -72,6 +72,17 @@ namespace MaceEvolve.Controls
         public bool UseSuccessBounds { get; set; }
         public Creature SelectedCreature { get; set; }
         public Color? SelectedCreaturePreviousColor { get; set; }
+        public Color GenLabelTextColor
+        {
+            get
+            {
+                return lblGenerationCount.ForeColor;
+            }
+            set
+            {
+                lblGenerationCount.ForeColor = value;
+            }
+        }
         #endregion
 
         #region Constructors
@@ -282,7 +293,7 @@ namespace MaceEvolve.Controls
 
             return SuccessfulCreaturesFitnesses;
         }
-        public bool MutateNetwork(NeuralNetwork Network, double CreateRandomNodeChance, double RemoveRandomNodeChance, double MutateRandomNodeBiasChance, double CreateRandomConnectionChance, double RemoveRandomConnectionChance,  double MutateRandomConnectionSourceChance, double MutateRandomConnectionTargetChance, double MutateRandomConnectionWeightChance)
+        public bool MutateNetwork(NeuralNetwork Network, double CreateRandomNodeChance, double RemoveRandomNodeChance, double MutateRandomNodeBiasChance, double CreateRandomConnectionChance, double RemoveRandomConnectionChance, double MutateRandomConnectionSourceChance, double MutateRandomConnectionTargetChance, double MutateRandomConnectionWeightChance)
         {
             List<CreatureInput> PossibleCreatureInputsToAdd = GetPossibleInputsToAdd(Network).ToList();
             List<CreatureAction> PossibleCreatureActionsToAdd = GetPossibleActionsToAdd(Network).ToList();

--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -25,7 +25,7 @@ namespace MaceEvolve.Controls
         public List<Creature> Creatures { get; set; } = new List<Creature>();
         public List<Food> Food { get; set; } = new List<Food>();
         public Stopwatch Stopwatch { get; set; } = new Stopwatch();
-        public int MaxCreatureAmount { get; set; } = 300;
+        public int MaxCreatureAmount { get; set; } = 150;
         public int MaxFoodAmount { get; set; } = 350;
         public int TargetFPS
         {
@@ -54,11 +54,11 @@ namespace MaceEvolve.Controls
         public Rectangle WorldBounds { get; set; }
         public Rectangle SuccessBounds { get; set; }
         public int MinCreatureConnections { get; set; } = 4;
-        public int MaxCreatureConnections { get; set; } = 64;
+        public int MaxCreatureConnections { get; set; } = 512;
         public double CreatureSpeed { get; set; }
         public double NewGenerationInterval { get; set; } = 12;
         public double SecondsUntilNewGeneration { get; set; } = 12;
-        public int MaxCreatureProcessNodes { get; set; } = 3;
+        public int MaxCreatureProcessNodes { get; set; } = 8;
         public double MutationChance { get; set; } = 0.1;
         public double MutationAttempts { get; set; } = 10;
         public double ConnectionWeightBound { get; set; } = 4;

--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -1,4 +1,5 @@
 ﻿using MaceEvolve.Enums;
+using MaceEvolve.Extensions;
 using MaceEvolve.Models;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,6 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Windows.Forms;
-using System.Xml.Linq;
 using Rectangle = System.Drawing.Rectangle;
 
 namespace MaceEvolve.Controls
@@ -65,6 +65,8 @@ namespace MaceEvolve.Controls
         public double MaxCreatureEnergy { get; set; } = 150;
         public double SuccessfulCreaturesPercentile { get; set; } = 10;
         public int GenerationCount { get; set; } = 1;
+        public double ReproductionNodeBiasVariance = 0.05;
+        public double ReproductionConnectionWeightVariance = 0.05;
         public ReadOnlyCollection<CreatureInput> PossibleCreatureInputs { get; } = Globals.AllCreatureInputs;
         public ReadOnlyCollection<CreatureAction> PossibleCreatureActions { get; } = Globals.AllCreatureActions;
         public bool UseSuccessBounds { get; set; }
@@ -127,7 +129,7 @@ namespace MaceEvolve.Controls
 
             List<Creature> NewCreatures = new List<Creature>();
 
-            Creature NewCreature = Creature.Reproduce(SuccessfulCreatures.ToList(), PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList());
+            Creature NewCreature = Creature.Reproduce(SuccessfulCreatures.ToList(), PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList(), ReproductionNodeBiasVariance, ReproductionConnectionWeightVariance, ConnectionWeightBound);
             NewCreature.GameHost = this;
             NewCreature.X = _Random.Next(WorldBounds.Left + WorldBounds.Width);
             NewCreature.Y = _Random.Next(WorldBounds.Top + WorldBounds.Height);
@@ -183,7 +185,7 @@ namespace MaceEvolve.Controls
                         {
                             if (NewCreatures.Count < MaxCreatureAmount)
                             {
-                                Creature NewCreature = Creature.Reproduce(new List<Creature>() { SuccessfulCreature }, PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList());
+                                Creature NewCreature = Creature.Reproduce(new List<Creature>() { SuccessfulCreature }, PossibleCreatureInputs.ToList(), PossibleCreatureActions.ToList(), ReproductionNodeBiasVariance, ReproductionConnectionWeightVariance, ConnectionWeightBound);
                                 NewCreature.GameHost = this;
                                 NewCreature.X = _Random.Next(WorldBounds.Left + WorldBounds.Width);
                                 NewCreature.Y = _Random.Next(WorldBounds.Top + WorldBounds.Height);
@@ -336,18 +338,18 @@ namespace MaceEvolve.Controls
                 }
 
                 if (NodeToAdd != null)
-            {
+                {
                     Network.AddNode(NodeToAdd);
                     MutationOccurred = true;
                 }
             }
 
             //Remove a random connection.
-                if (Network.Connections.Count > MinCreatureConnections && _Random.NextDouble() <= RemoveRandomConnectionChance)
-                {
+            if (Network.Connections.Count > MinCreatureConnections && _Random.NextDouble() <= RemoveRandomConnectionChance)
+            {
                 Connection RandomConnection = Network.Connections[_Random.Next(Network.Connections.Count)];
                 Network.Connections.Remove(RandomConnection);
-                }
+            }
 
             //Change a random connection's weight.
             if (_Random.NextDouble() <= MutateRandomConnectionWeightChance)

--- a/MaceEvolve/Controls/NeuralNetworkViewer.Designer.cs
+++ b/MaceEvolve/Controls/NeuralNetworkViewer.Designer.cs
@@ -1,0 +1,132 @@
+﻿namespace MaceEvolve.Controls
+{
+    partial class NeuralNetworkViewer
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.DrawTimer = new System.Windows.Forms.Timer(this.components);
+            this.lblSelectedNodePreviousOutput = new System.Windows.Forms.Label();
+            this.lblSelectedNodeId = new System.Windows.Forms.Label();
+            this.lblNetworkConnectionsCount = new System.Windows.Forms.Label();
+            this.lblNetworkNodesCount = new System.Windows.Forms.Label();
+            this.lblSelectedNodeConnectionCount = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // DrawTimer
+            // 
+            this.DrawTimer.Enabled = true;
+            this.DrawTimer.Interval = 17;
+            this.DrawTimer.Tick += new System.EventHandler(this.DrawTimer_Tick);
+            // 
+            // lblSelectedNodePreviousOutput
+            // 
+            this.lblSelectedNodePreviousOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblSelectedNodePreviousOutput.AutoSize = true;
+            this.lblSelectedNodePreviousOutput.BackColor = System.Drawing.Color.Transparent;
+            this.lblSelectedNodePreviousOutput.Font = new System.Drawing.Font("Yu Gothic UI", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblSelectedNodePreviousOutput.Location = new System.Drawing.Point(15, 457);
+            this.lblSelectedNodePreviousOutput.Name = "lblSelectedNodePreviousOutput";
+            this.lblSelectedNodePreviousOutput.Size = new System.Drawing.Size(217, 32);
+            this.lblSelectedNodePreviousOutput.TabIndex = 4;
+            this.lblSelectedNodePreviousOutput.Text = "Previous Output: 0";
+            // 
+            // lblSelectedNodeId
+            // 
+            this.lblSelectedNodeId.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblSelectedNodeId.AutoSize = true;
+            this.lblSelectedNodeId.BackColor = System.Drawing.Color.Transparent;
+            this.lblSelectedNodeId.Font = new System.Drawing.Font("Yu Gothic UI", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblSelectedNodeId.Location = new System.Drawing.Point(15, 408);
+            this.lblSelectedNodeId.Name = "lblSelectedNodeId";
+            this.lblSelectedNodeId.Size = new System.Drawing.Size(61, 32);
+            this.lblSelectedNodeId.TabIndex = 4;
+            this.lblSelectedNodeId.Text = "Id: 0";
+            // 
+            // lblNetworkConnectionsCount
+            // 
+            this.lblNetworkConnectionsCount.AutoSize = true;
+            this.lblNetworkConnectionsCount.BackColor = System.Drawing.Color.Transparent;
+            this.lblNetworkConnectionsCount.Font = new System.Drawing.Font("Yu Gothic UI", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblNetworkConnectionsCount.Location = new System.Drawing.Point(15, 11);
+            this.lblNetworkConnectionsCount.Name = "lblNetworkConnectionsCount";
+            this.lblNetworkConnectionsCount.Size = new System.Drawing.Size(174, 32);
+            this.lblNetworkConnectionsCount.TabIndex = 4;
+            this.lblNetworkConnectionsCount.Text = "Connections: 0";
+            // 
+            // lblNetworkNodesCount
+            // 
+            this.lblNetworkNodesCount.AutoSize = true;
+            this.lblNetworkNodesCount.BackColor = System.Drawing.Color.Transparent;
+            this.lblNetworkNodesCount.Font = new System.Drawing.Font("Yu Gothic UI", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblNetworkNodesCount.Location = new System.Drawing.Point(15, 62);
+            this.lblNetworkNodesCount.Name = "lblNetworkNodesCount";
+            this.lblNetworkNodesCount.Size = new System.Drawing.Size(109, 32);
+            this.lblNetworkNodesCount.TabIndex = 4;
+            this.lblNetworkNodesCount.Text = "Nodes: 0";
+            // 
+            // lblSelectedNodeConnectionCount
+            // 
+            this.lblSelectedNodeConnectionCount.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblSelectedNodeConnectionCount.AutoSize = true;
+            this.lblSelectedNodeConnectionCount.BackColor = System.Drawing.Color.Transparent;
+            this.lblSelectedNodeConnectionCount.Font = new System.Drawing.Font("Yu Gothic UI", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblSelectedNodeConnectionCount.Location = new System.Drawing.Point(15, 509);
+            this.lblSelectedNodeConnectionCount.Name = "lblSelectedNodeConnectionCount";
+            this.lblSelectedNodeConnectionCount.Size = new System.Drawing.Size(174, 32);
+            this.lblSelectedNodeConnectionCount.TabIndex = 4;
+            this.lblSelectedNodeConnectionCount.Text = "Connections: 0";
+            // 
+            // NeuralNetworkViewer
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.lblNetworkNodesCount);
+            this.Controls.Add(this.lblSelectedNodeConnectionCount);
+            this.Controls.Add(this.lblNetworkConnectionsCount);
+            this.Controls.Add(this.lblSelectedNodeId);
+            this.Controls.Add(this.lblSelectedNodePreviousOutput);
+            this.Name = "NeuralNetworkViewer";
+            this.Size = new System.Drawing.Size(886, 561);
+            this.Paint += new System.Windows.Forms.PaintEventHandler(this.NeuralNetworkViewer_Paint);
+            this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.NeuralNetworkViewer_MouseDown);
+            this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.NeuralNetworkViewer_MouseMove);
+            this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.NeuralNetworkViewer_MouseUp);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        public System.Windows.Forms.Timer DrawTimer;
+        public System.Windows.Forms.Label lblSelectedNodePreviousOutput;
+        public System.Windows.Forms.Label lblSelectedNodeId;
+        public System.Windows.Forms.Label lblNetworkConnectionsCount;
+        public System.Windows.Forms.Label lblNetworkNodesCount;
+        public System.Windows.Forms.Label lblSelectedNodeConnectionCount;
+    }
+}

--- a/MaceEvolve/Controls/NeuralNetworkViewer.cs
+++ b/MaceEvolve/Controls/NeuralNetworkViewer.cs
@@ -1,0 +1,250 @@
+﻿using MaceEvolve.Models;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Windows.Forms;
+
+namespace MaceEvolve.Controls
+{
+    public partial class NeuralNetworkViewer : UserControl
+    {
+        #region Fields
+        public NeuralNetwork _NeuralNetwork;
+        #endregion
+
+        #region Properties
+        public NeuralNetwork NeuralNetwork
+        {
+            get
+            {
+                return _NeuralNetwork;
+            }
+            set
+            {
+                if (_NeuralNetwork != value)
+                {
+                    SelectedNodeId = null;
+                    MovingNodeId = null;
+
+                    _NeuralNetwork = value;
+
+                    ResetDrawnNodes();
+                }
+            }
+        }
+        private Dictionary<NodeType, Color> _NodeTypeToColorDict { get; } = new Dictionary<NodeType, Color>()
+        {
+            { NodeType.Input, Color.Blue },
+            { NodeType.Process, Color.Gray },
+            { NodeType.Output, Color.Orange }
+        };
+        private Dictionary<NodeType, Brush> _NodeTypeToBrushDict { get; }
+        private Dictionary<int, GameObject> DrawnNodeIdsToGameObject { get; set; } = new Dictionary<int, GameObject>();
+        public int NodeSize = 75;
+        public int NodeFontSize = 14;
+        public int? SelectedNodeId { get; set; }
+        public int? MovingNodeId { get; set; }
+        #endregion
+
+        #region Constructors
+        public NeuralNetworkViewer()
+            : this(null)
+        {
+        }
+        public NeuralNetworkViewer(NeuralNetwork NeuralNetwork)
+        {
+            this.NeuralNetwork = NeuralNetwork;
+
+            _NodeTypeToBrushDict = new Dictionary<NodeType, Brush>()
+            {
+                { NodeType.Input, new SolidBrush(_NodeTypeToColorDict[NodeType.Input]) },
+                { NodeType.Process, new SolidBrush(_NodeTypeToColorDict[NodeType.Process]) },
+                { NodeType.Output, new SolidBrush(_NodeTypeToColorDict[NodeType.Output]) }
+            };
+
+            DoubleBuffered = true;
+
+            InitializeComponent();
+        }
+        #endregion
+
+        #region Methods
+        public void ResetDrawnNodes()
+        {
+            DrawnNodeIdsToGameObject.Clear();
+
+            Dictionary<int, Node> NodeIdsToNodesDict = NeuralNetwork.NodeIdsToNodesDict.ToDictionary(x => x.Key, x => x.Value);
+
+            foreach (var KeyValuePair in NodeIdsToNodesDict)
+            {
+                int NodeId = KeyValuePair.Key;
+                Node Node = KeyValuePair.Value;
+
+                GameObject NodeGameObject = new GameObject();
+                NodeGameObject.Size = NodeSize;
+
+                int XLowerimit;
+                int XUpperLimit;
+                switch (Node.NodeType)
+                {
+                    case NodeType.Input:
+                        XLowerimit = Bounds.Left;
+                        XUpperLimit = (Bounds.Left + Bounds.Width / 3) - (int)NodeGameObject.Size;
+                        break;
+
+                    case NodeType.Process:
+                        XLowerimit = Bounds.Left + Bounds.Width / 3;
+                        XUpperLimit = (Bounds.Left + (Bounds.Width / 3) * 2) - (int)NodeGameObject.Size;
+                        break;
+
+                    case NodeType.Output:
+                        XLowerimit = Bounds.Left + (Bounds.Left + (Bounds.Width / 3) * 2);
+                        XUpperLimit = (Bounds.Left + (Bounds.Width / 3) * 3) - (int)NodeGameObject.Size;
+                        break;
+
+                    default:
+                        throw new NotImplementedException(nameof(Node.NodeType));
+                }
+
+                NodeGameObject.X = Globals.Random.Next(XLowerimit, XUpperLimit);
+                NodeGameObject.Y = Globals.Random.Next(Bounds.Bottom - (int)NodeGameObject.Size);
+
+                DrawnNodeIdsToGameObject.Add(NodeId, NodeGameObject);
+            }
+        }
+
+        private void NeuralNetworkViewer_Paint(object sender, PaintEventArgs e)
+        {
+            if (NeuralNetwork != null)
+            {
+                Node SelectedNode = SelectedNodeId == null ? null : NeuralNetwork.NodeIdsToNodesDict[SelectedNodeId.Value];
+                e.Graphics.SmoothingMode = SmoothingMode.HighQuality;
+                e.Graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+
+                //Draw connections between nodes.
+                //Currently, duplicate connections will draw over each other. Self referencing connections aren't supported.
+                List<Connection> NetworkConnectionsList = NeuralNetwork.Connections.ToList();
+                foreach (var Connection in NetworkConnectionsList)
+                {
+                    GameObject SourceIdGameObject;
+                    GameObject TargetIdGameObject;
+
+                    if (DrawnNodeIdsToGameObject.TryGetValue(Connection.SourceId, out SourceIdGameObject) && DrawnNodeIdsToGameObject.TryGetValue(Connection.TargetId, out TargetIdGameObject))
+                    {
+                        Color PenColor;
+                        float PenSize;
+                        if (Connection.Weight == 0)
+                        {
+                            PenColor = Color.Gray;
+                            PenSize = (int)Globals.Map(Connection.Weight, -4, 4, 2, 8);
+                        }
+                        if (Connection.Weight > 0)
+                        {
+                            PenColor = Color.FromArgb(0, (int)Globals.Map(Connection.Weight, 0, 4, 0, 255), 0);
+                            PenSize = (int)Globals.Map(Connection.Weight, 0, 4, 2, 8);
+                        }
+                        else
+                        {
+                            PenColor = Color.FromArgb((int)Globals.Map(Connection.Weight, 0, -4, 0, 255), 0, 0);
+                            PenSize = (int)Globals.Map(Connection.Weight, 0, -4, 2, 8);
+                        }
+
+                        e.Graphics.DrawLine(new Pen(PenColor, PenSize), (int)SourceIdGameObject.MX, (int)SourceIdGameObject.MY, (int)TargetIdGameObject.MX, (int)TargetIdGameObject.MY);
+                    }
+                }
+
+                NeuralNetworkStepInfo HighestOutputNodeStepInfo = NeuralNetwork.PreviousStepInfo.Where(x => x.NodeType == NodeType.Output).OrderBy(x => x.PreviousOutput).LastOrDefault();
+
+                //Draw nodes.
+                foreach (var KeyValuePair in DrawnNodeIdsToGameObject)
+                {
+                    int NodeId = KeyValuePair.Key;
+                    Node Node = NeuralNetwork.NodeIdsToNodesDict[NodeId];
+                    GameObject NodeGameObject = KeyValuePair.Value;
+
+                    Brush NodeBrush = _NodeTypeToBrushDict[Node.NodeType];
+
+                    NeuralNetworkStepInfo NodeNetworkStepInfo = NeuralNetwork.PreviousStepInfo.FirstOrDefault(x => x.NodeId == NodeId);
+                    string PreviousOutputString = NodeNetworkStepInfo == null ? null : string.Format("{0:0.##}", NodeNetworkStepInfo.PreviousOutput);
+                    int NodeIdFontSize = NodeFontSize - 4;
+                    int NodePreviousOutputFontSize = NodeFontSize;
+
+                    e.Graphics.FillEllipse(NodeBrush, (float)NodeGameObject.X, (float)NodeGameObject.Y, (float)NodeGameObject.Size, (float)NodeGameObject.Size);
+
+                    if (HighestOutputNodeStepInfo != null && NodeNetworkStepInfo == HighestOutputNodeStepInfo)
+                    {
+                        e.Graphics.DrawEllipse(new Pen(Color.White, 3), (float)NodeGameObject.X, (float)NodeGameObject.Y, (float)NodeGameObject.Size, (float)NodeGameObject.Size);
+                    }
+
+                    if (NodeId == SelectedNodeId)
+                    {
+                        e.Graphics.DrawEllipse(new Pen(Color.White, 6), (float)NodeGameObject.X, (float)NodeGameObject.Y, (float)NodeGameObject.Size, (float)NodeGameObject.Size);
+                    }
+
+                    e.Graphics.DrawString($"{NodeId}", new Font(FontFamily.GenericSansSerif, NodeIdFontSize, FontStyle.Bold), new SolidBrush(Color.Black), (float)NodeGameObject.MX - NodeIdFontSize, (float)NodeGameObject.MY - NodePreviousOutputFontSize * 2);
+                    e.Graphics.DrawString(PreviousOutputString, new Font(FontFamily.GenericSansSerif, NodePreviousOutputFontSize), new SolidBrush(Color.Black), (float)NodeGameObject.MX - NodePreviousOutputFontSize * 2, (float)NodeGameObject.MY);
+
+                }
+
+                lblNetworkConnectionsCount.Text = $"Connections: {NeuralNetwork.Connections.Count}";
+                lblNetworkNodesCount.Text = $"Nodes: {NeuralNetwork.NodeIdsToNodesDict.Count}";
+
+                lblSelectedNodeId.Visible = SelectedNodeId != null;
+                lblSelectedNodePreviousOutput.Visible = SelectedNodeId != null;
+                lblSelectedNodeConnectionCount.Visible = SelectedNodeId != null;
+                if (SelectedNodeId != null)
+                {
+                    lblSelectedNodeId.Text = $"Id: {SelectedNodeId}";
+                    lblSelectedNodePreviousOutput.Text = $"Previous Output: {NeuralNetwork.PreviousStepInfo.FirstOrDefault(x => x.NodeId == SelectedNodeId).PreviousOutput}";
+                    lblSelectedNodeConnectionCount.Text = $"Connections: {NetworkConnectionsList.Where(x => x.SourceId == SelectedNodeId || x.TargetId == SelectedNodeId).Count()}";
+                }
+
+
+            }
+        }
+        private void NeuralNetworkViewer_MouseDown(object sender, MouseEventArgs e)
+        {
+            Point RelativeMouseLocation = new Point(e.X - Bounds.Location.X, e.Y - Bounds.Location.Y);
+
+            Dictionary<int, GameObject> NodeIdsOrderedByDistanceToMouse = DrawnNodeIdsToGameObject.OrderBy(x => Globals.GetDistanceFrom(RelativeMouseLocation.X, RelativeMouseLocation.Y, x.Value.MX, x.Value.MY)).ToDictionary(x => x.Key, x => x.Value);
+
+            int? ClosestNodeId = NodeIdsOrderedByDistanceToMouse.Count == 0 ? null : NodeIdsOrderedByDistanceToMouse.FirstOrDefault().Key;
+
+            if (ClosestNodeId == null || Globals.GetDistanceFrom(RelativeMouseLocation.X, RelativeMouseLocation.Y, NodeIdsOrderedByDistanceToMouse[ClosestNodeId.Value].MX, NodeIdsOrderedByDistanceToMouse[ClosestNodeId.Value].MY) > NodeIdsOrderedByDistanceToMouse[ClosestNodeId.Value].Size / 2)
+            {
+                SelectedNodeId = null;
+            }
+            else
+            {
+                SelectedNodeId = ClosestNodeId.Value;
+            }
+
+            MovingNodeId = SelectedNodeId;
+        }
+        private void NeuralNetworkViewer_MouseUp(object sender, MouseEventArgs e)
+        {
+            MovingNodeId = null;
+        }
+        private void NeuralNetworkViewer_MouseMove(object sender, MouseEventArgs e)
+        {
+            Point RelativeMouseLocation = new Point(e.X - Bounds.Location.X, e.Y - Bounds.Location.Y);
+
+            if (MovingNodeId != null)
+            {
+                GameObject MovingNodeGameObject = DrawnNodeIdsToGameObject[MovingNodeId.Value];
+
+                MovingNodeGameObject.X = RelativeMouseLocation.X - MovingNodeGameObject.Size / 2;
+                MovingNodeGameObject.Y = RelativeMouseLocation.Y - MovingNodeGameObject.Size / 2;
+            }
+        }
+        private void DrawTimer_Tick(object sender, System.EventArgs e)
+        {
+            Invalidate();
+        }
+        #endregion
+    }
+}

--- a/MaceEvolve/Controls/NeuralNetworkViewer.resx
+++ b/MaceEvolve/Controls/NeuralNetworkViewer.resx
@@ -1,0 +1,63 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="DrawTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/MaceEvolve/Enums/CreatureInput.cs
+++ b/MaceEvolve/Enums/CreatureInput.cs
@@ -8,6 +8,7 @@
         VerticalProximityToFood,
         HorizontalProximityToFood,
         DistanceFromTopWorldBound,
-        DistanceFromLeftWorldBound
+        DistanceFromLeftWorldBound,
+        RandomInput
     }
 }

--- a/MaceEvolve/Extensions/RandomExtensions.cs
+++ b/MaceEvolve/Extensions/RandomExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MaceEvolve.Models;
+using System;
 
 namespace MaceEvolve.Extensions
 {
@@ -7,6 +8,12 @@ namespace MaceEvolve.Extensions
         public static double NextDouble(this Random Random, double MinValue, double MaxValue)
         {
             return Random.NextDouble() * (MaxValue - MinValue) + MinValue;
+        }
+        public static double NextDoubleVariance(this Random Random, double Value, double Variance)
+        {
+            double Multiplier = Random.NextDouble(1 - Variance, 1 + Variance);
+
+            return Value * Multiplier;
         }
     }
 }

--- a/MaceEvolve/MainForm.Designer.cs
+++ b/MaceEvolve/MainForm.Designer.cs
@@ -34,6 +34,7 @@ namespace MaceEvolve
             this.StopButton = new System.Windows.Forms.Button();
             this.ResetButton = new System.Windows.Forms.Button();
             this.NextGenButton = new System.Windows.Forms.Button();
+            this.btnTrackBestCreature = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // StartButton
@@ -92,12 +93,27 @@ namespace MaceEvolve
             this.NextGenButton.UseVisualStyleBackColor = false;
             this.NextGenButton.Click += new System.EventHandler(this.NextGenButton_Click);
             // 
+            // btnTrackBestCreature
+            // 
+            this.btnTrackBestCreature.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnTrackBestCreature.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.btnTrackBestCreature.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnTrackBestCreature.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnTrackBestCreature.Location = new System.Drawing.Point(616, 50);
+            this.btnTrackBestCreature.Name = "btnTrackBestCreature";
+            this.btnTrackBestCreature.Size = new System.Drawing.Size(156, 32);
+            this.btnTrackBestCreature.TabIndex = 2;
+            this.btnTrackBestCreature.Text = "Track Best Creature";
+            this.btnTrackBestCreature.UseVisualStyleBackColor = false;
+            this.btnTrackBestCreature.Click += new System.EventHandler(this.btnTrackBestCreature_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(32)))), ((int)(((byte)(32)))));
             this.ClientSize = new System.Drawing.Size(784, 661);
+            this.Controls.Add(this.btnTrackBestCreature);
             this.Controls.Add(this.NextGenButton);
             this.Controls.Add(this.ResetButton);
             this.Controls.Add(this.StopButton);
@@ -114,5 +130,6 @@ namespace MaceEvolve
         private Button StopButton;
         private Button ResetButton;
         private Button NextGenButton;
+        private Button btnTrackBestCreature;
     }
 }

--- a/MaceEvolve/MainForm.cs
+++ b/MaceEvolve/MainForm.cs
@@ -34,5 +34,10 @@ namespace MaceEvolve
             MainGameHost.SecondsUntilNewGeneration = 0;
             MainGameHost.NewGenerationTimer_Tick(this, e);
         }
+
+        private void btnTrackBestCreature_Click(object sender, EventArgs e)
+        {
+            MainGameHost.BestCreatureNetworkViewerForm.Show();
+        }
     }
 }

--- a/MaceEvolve/MainForm.cs
+++ b/MaceEvolve/MainForm.cs
@@ -1,12 +1,13 @@
 using MaceEvolve.Controls;
 using System;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace MaceEvolve
 {
     public partial class MainForm : Form
     {
-        public GameHost MainGameHost = new GameHost() { Dock = DockStyle.Fill };
+        public GameHost MainGameHost = new GameHost() { Dock = DockStyle.Fill, GenLabelTextColor = Color.White };
         public MainForm()
         {
             InitializeComponent();

--- a/MaceEvolve/Models/Creature.cs
+++ b/MaceEvolve/Models/Creature.cs
@@ -126,6 +126,7 @@ namespace MaceEvolve.Models
             Brain.UpdateInputValue(CreatureInput.HorizontalProximityToCreature, HorizontalProximityToCreature());
             Brain.UpdateInputValue(CreatureInput.DistanceFromTopWorldBound, DistanceFromTopWorldBound());
             Brain.UpdateInputValue(CreatureInput.DistanceFromLeftWorldBound, DistanceFromLeftWorldBound());
+            Brain.UpdateInputValue(CreatureInput.RandomInput, RandomInput());
         }
         public static Creature Reproduce(IList<Creature> Parents, List<CreatureInput> Inputs, List<CreatureAction> Actions, double NodeBiasMaxVariancePercentage, double ConnectionWeightMaxVariancePercentage, double ConnectionWeightBound)
         {
@@ -289,6 +290,10 @@ namespace MaceEvolve.Models
         public double DistanceFromLeftWorldBound()
         {
             return Globals.Map(X, GameHost.WorldBounds.Left, GameHost.WorldBounds.Right, 0, 1);
+        }
+        public double RandomInput()
+        {
+            return Globals.Random.NextDouble();
         }
         #endregion
 

--- a/MaceEvolve/Models/Creature.cs
+++ b/MaceEvolve/Models/Creature.cs
@@ -129,9 +129,9 @@ namespace MaceEvolve.Models
         public static Creature Reproduce(IList<Creature> Parents, List<CreatureInput> Inputs, List<CreatureAction> Actions)
         {
             Dictionary<Creature, List<Connection>> AvailableParentConnections = Parents.ToDictionary(x => x, x => x.Brain.Connections.ToList());
-            Dictionary<Creature, Dictionary<int, int>> ParentToOffSpringNodesMap = new Dictionary<Creature, Dictionary<int, int>>();
+            Dictionary<Creature, Dictionary<int, int>> ParentToOffspringNodesMap = new Dictionary<Creature, Dictionary<int, int>>();
 
-            Creature OffSpring = new Creature()
+            Creature Offspring = new Creature()
             {
                 Brain = new NeuralNetwork(new List<Node>(), Inputs, Actions, new List<Connection>())
             };
@@ -143,7 +143,7 @@ namespace MaceEvolve.Models
                 AverageNumberOfParentConnections = 1;
             }
 
-            while (OffSpring.Brain.Connections.Count < AverageNumberOfParentConnections)
+            while (Offspring.Brain.Connections.Count < AverageNumberOfParentConnections)
             {
                 Creature RandomParent = Parents[Globals.Random.Next(Parents.Count)];
                 List<Connection> RandomParentAvailableConnections = AvailableParentConnections[RandomParent];
@@ -152,50 +152,50 @@ namespace MaceEvolve.Models
                 {
                     Connection RandomParentConnection = RandomParentAvailableConnections[Globals.Random.Next(RandomParentAvailableConnections.Count)];
 
-                    //If a parent's node has not been added and mapped to an offspring's node, create a new node and map it to the parent's node.
-                    if (!(ParentToOffSpringNodesMap.ContainsKey(RandomParent) && ParentToOffSpringNodesMap[RandomParent].ContainsKey(RandomParentConnection.SourceId)))
+                    //If a parent's node has not been added and mapped to an Offspring's node, create a new node and map it to the parent's node.
+                    if (!(ParentToOffspringNodesMap.ContainsKey(RandomParent) && ParentToOffspringNodesMap[RandomParent].ContainsKey(RandomParentConnection.SourceId)))
                     {
                         Node RandomParentConnectionSourceNode = RandomParent.Brain.NodeIdsToNodesDict[RandomParentConnection.SourceId];
                         Node NewNode = new Node(RandomParentConnectionSourceNode.NodeType, RandomParentConnectionSourceNode.Bias, RandomParentConnectionSourceNode.CreatureInput, RandomParentConnectionSourceNode.CreatureAction);
-                        int NewNodeId = OffSpring.Brain.AddNode(NewNode);
+                        int NewNodeId = Offspring.Brain.AddNode(NewNode);
 
-                        //Map the newly added offspring node to the parent's node so that duplicates aren't created if two of the parent's connections reference the same node.
-                        if (!ParentToOffSpringNodesMap.ContainsKey(RandomParent))
+                        //Map the newly added Offspring node to the parent's node so that duplicates aren't created if two of the parent's connections reference the same node.
+                        if (!ParentToOffspringNodesMap.ContainsKey(RandomParent))
                         {
-                            ParentToOffSpringNodesMap.Add(RandomParent, new Dictionary<int, int>());
+                            ParentToOffspringNodesMap.Add(RandomParent, new Dictionary<int, int>());
                         }
 
-                        ParentToOffSpringNodesMap[RandomParent][RandomParentConnection.SourceId] = NewNodeId;
+                        ParentToOffspringNodesMap[RandomParent][RandomParentConnection.SourceId] = NewNodeId;
                     }
 
-                    if (!(ParentToOffSpringNodesMap.ContainsKey(RandomParent) && ParentToOffSpringNodesMap[RandomParent].ContainsKey(RandomParentConnection.TargetId)))
+                    if (!(ParentToOffspringNodesMap.ContainsKey(RandomParent) && ParentToOffspringNodesMap[RandomParent].ContainsKey(RandomParentConnection.TargetId)))
                     {
                         Node RandomParentConnectionTargetNode = RandomParent.Brain.NodeIdsToNodesDict[RandomParentConnection.TargetId];
                         Node NewNode = new Node(RandomParentConnectionTargetNode.NodeType, RandomParentConnectionTargetNode.Bias, RandomParentConnectionTargetNode.CreatureInput, RandomParentConnectionTargetNode.CreatureAction);
-                        int NewNodeId = OffSpring.Brain.AddNode(NewNode);
+                        int NewNodeId = Offspring.Brain.AddNode(NewNode);
 
-                        //Map the newly added offspring node to the parent's node so that duplicates aren't created if two of the parent's connections reference the same node.
-                        if (!ParentToOffSpringNodesMap.ContainsKey(RandomParent))
+                        //Map the newly added Offspring node to the parent's node so that duplicates aren't created if two of the parent's connections reference the same node.
+                        if (!ParentToOffspringNodesMap.ContainsKey(RandomParent))
                         {
-                            ParentToOffSpringNodesMap.Add(RandomParent, new Dictionary<int, int>());
+                            ParentToOffspringNodesMap.Add(RandomParent, new Dictionary<int, int>());
                         }
 
-                        ParentToOffSpringNodesMap[RandomParent][RandomParentConnection.TargetId] = NewNodeId;
+                        ParentToOffspringNodesMap[RandomParent][RandomParentConnection.TargetId] = NewNodeId;
                     }
 
                     Connection ConnectionToAdd = new Connection()
                     {
                         Weight = RandomParentConnection.Weight,
-                        SourceId = ParentToOffSpringNodesMap[RandomParent][RandomParentConnection.SourceId],
-                        TargetId = ParentToOffSpringNodesMap[RandomParent][RandomParentConnection.TargetId]
+                        SourceId = ParentToOffspringNodesMap[RandomParent][RandomParentConnection.SourceId],
+                        TargetId = ParentToOffspringNodesMap[RandomParent][RandomParentConnection.TargetId]
                     };
 
-                    OffSpring.Brain.Connections.Add(ConnectionToAdd);
+                    Offspring.Brain.Connections.Add(ConnectionToAdd);
                     AvailableParentConnections[RandomParent].Remove(RandomParentConnection);
                 }
             }
 
-            return OffSpring;
+            return Offspring;
         }
 
         #region CreatureValues

--- a/MaceEvolve/Models/GameObject.cs
+++ b/MaceEvolve/Models/GameObject.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms;
 
 namespace MaceEvolve.Models
 {
-    public abstract class GameObject
+    public class GameObject
     {
         #region Fields
         private Rectangle _Rectangle = new Rectangle(0, 0, 0, 0);

--- a/MaceEvolve/Models/NeuralNetwork.cs
+++ b/MaceEvolve/Models/NeuralNetwork.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.DirectoryServices;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -116,154 +117,6 @@ namespace MaceEvolve.Models
         {
             return JsonConvert.DeserializeObject<NeuralNetwork>(JsonConvert.SerializeObject(this));
         }
-        public static bool MutateNodeBias(double MutationChance, Node Node)
-        {
-            if (Globals.Random.NextDouble() <= MutationChance)
-            {
-                Node.Bias = Globals.Map(Globals.Random.NextDouble(), 0, 1, -1, 1);
-
-                return true;
-            }
-
-            return false;
-        }
-        public static Node GetInputNodeToAdd(double AddNodeChance, IList<Node> Nodes, IEnumerable<CreatureInput> PossibleInputs)
-        {
-            if (Globals.Random.NextDouble() <= AddNodeChance)
-            {
-                IEnumerable<Node> InputNodes = Nodes.Where(x => x.NodeType == NodeType.Input);
-                //Possible inputs are any that aren't already present in the creature.
-                List<CreatureInput> PossibleInputsToAdd = PossibleInputs.Where(x => !InputNodes.Any(y => y.CreatureInput == x)).ToList();
-
-                if (PossibleInputsToAdd.Count > 0)
-                {
-                    CreatureInput RandomPossibleInput = PossibleInputsToAdd[Globals.Random.Next(PossibleInputsToAdd.Count)];
-                    Node NewNode = new Node(NodeType.Input, Globals.Map(Globals.Random.NextDouble(), 0, 1, -1, 1), CreatureInput: RandomPossibleInput);
-                    Nodes.Add(NewNode);
-
-                    return NewNode;
-                }
-            }
-
-            return null;
-        }
-        public static Node GetInputNodeToRemove(double RemoveNodeChance, IEnumerable<Node> Nodes)
-        {
-            if (Globals.Random.NextDouble() <= RemoveNodeChance)
-            {
-                List<Node> InputNodes = Nodes.Where(x => x.NodeType == NodeType.Input).ToList();
-
-                if (InputNodes.Count > 0)
-                {
-                    return InputNodes[Globals.Random.Next(InputNodes.Count)];
-                }
-            }
-
-            return null;
-        }
-        public static Node GetProcessNodeToAdd(double AddNodeChance)
-        {
-            if (Globals.Random.NextDouble() <= AddNodeChance)
-            {
-                Node NewNode = new Node(NodeType.Process, Globals.Map(Globals.Random.NextDouble(), 0, 1, -1, 1));
-
-                return NewNode;
-            }
-
-            return null;
-        }
-        public static Node GetProcessNodeToRemove(double RemoveNodeChance, IEnumerable<Node> Nodes)
-        {
-            if (Globals.Random.NextDouble() <= RemoveNodeChance)
-            {
-                List<Node> ProcessNodes = Nodes.Where(x => x.NodeType == NodeType.Process).ToList();
-
-                if (ProcessNodes.Count > 0)
-                {
-                    return ProcessNodes[Globals.Random.Next(ProcessNodes.Count)];
-                }
-            }
-
-            return null;
-        }
-        public static Node GetOutputNodeToAdd(double AddNodeChance, IList<Node> Nodes, IEnumerable<CreatureAction> PossibleActions)
-        {
-            if (Globals.Random.NextDouble() <= AddNodeChance)
-            {
-                IEnumerable<Node> OutputNodes = Nodes.Where(x => x.NodeType == NodeType.Output);
-                //Possible outputs are any that aren't already present in the creature.
-                List<CreatureAction> PossibleActionsToAdd = PossibleActions.Where(x => !OutputNodes.Any(y => y.CreatureAction == x)).ToList();
-
-                if (PossibleActionsToAdd.Count > 0)
-                {
-                    CreatureAction RandomPossibleAction = PossibleActionsToAdd[Globals.Random.Next(PossibleActionsToAdd.Count)];
-                    Node NewNode = new Node(NodeType.Output, Globals.Map(Globals.Random.NextDouble(), 0, 1, -1, 1), CreatureAction: RandomPossibleAction);
-                    Nodes.Add(NewNode);
-
-                    return NewNode;
-                }
-            }
-
-            return null;
-        }
-        public static Node GetOutputNodeToRemove(double RemoveNodeChance, IEnumerable<Node> Nodes)
-        {
-            if (Globals.Random.NextDouble() <= RemoveNodeChance)
-            {
-                List<Node> OutputNodes = Nodes.Where(x => x.NodeType == NodeType.Output).ToList();
-
-                if (OutputNodes.Count > 0)
-                {
-                    return OutputNodes[Globals.Random.Next(OutputNodes.Count)];
-                }
-            }
-
-            return null;
-        }
-        public static Node GetNodeToAdd(double InputNodeChance, double ProcessNodeChance, double OutputNodeChance, IList<Node> Nodes, IEnumerable<CreatureInput> PossibleInputs, IEnumerable<CreatureAction> PossibleActions)
-        {
-            double TotalChance = InputNodeChance + ProcessNodeChance + OutputNodeChance;
-
-            if (TotalChance > 0)
-            {
-                if (Globals.Random.NextDouble() <= InputNodeChance / TotalChance)
-                {
-                    return GetInputNodeToAdd(1, Nodes, PossibleInputs);
-                }
-                else if (Globals.Random.NextDouble() <= ProcessNodeChance / TotalChance)
-                {
-                    return GetProcessNodeToAdd(1);
-                }
-                else if (Globals.Random.NextDouble() <= OutputNodeChance / TotalChance)
-                {
-                    return GetOutputNodeToAdd(1, Nodes, PossibleActions);
-                }
-            }
-
-            return null;
-        }
-        public static Node GetNodeToRemove(double InputNodeChance, double ProcessNodeChance, double OutputNodeChance, IEnumerable<Node> Nodes)
-        {
-            double TotalChance = InputNodeChance + ProcessNodeChance + OutputNodeChance;
-
-            if (TotalChance > 0)
-            {
-                if (Globals.Random.NextDouble() <= InputNodeChance / TotalChance)
-                {
-                    return GetInputNodeToRemove(1, Nodes);
-                }
-                else if (Globals.Random.NextDouble() <= ProcessNodeChance / TotalChance)
-                {
-                    return GetProcessNodeToRemove(1, Nodes);
-                }
-                else if (Globals.Random.NextDouble() <= OutputNodeChance / TotalChance)
-                {
-                    return GetOutputNodeToRemove(1, Nodes);
-                }
-            }
-
-            return null;
-        }
         public bool MutateConnectionTarget(double MutationChance, Connection Connection)
         {
             List<Node> PossibleTargetNodes = GetPossibleTargetNodes(NodeIdsToNodesDict.Values).ToList();
@@ -290,17 +143,6 @@ namespace MaceEvolve.Models
                 Node RandomNode = PossibleSourceNodes[RandomNodeNum];
 
                 Connection.SourceId = NodesToNodeIdsDict[RandomNode];
-
-                return true;
-            }
-
-            return false;
-        }
-        public static bool MutateConnectionWeight(double MutationChance, Connection Connection, double ConnectionWeightBound)
-        {
-            if (Globals.Random.NextDouble() <= MutationChance)
-            {
-                Connection.Weight = Globals.Map(Globals.Random.NextDouble(), 0, 1, -ConnectionWeightBound, ConnectionWeightBound);
 
                 return true;
             }
@@ -622,7 +464,7 @@ namespace MaceEvolve.Models
                 {
                     NodeId = i;
                     NodeIdCreated = true;
-            }
+                }
             }
 
             _NodeIdsToNodesDict[NodeId] = Node;

--- a/MaceEvolve/Models/NeuralNetwork.cs
+++ b/MaceEvolve/Models/NeuralNetwork.cs
@@ -62,15 +62,7 @@ namespace MaceEvolve.Models
         #region Methods
         public void UpdateInputValue(CreatureInput CreatureInput, double Value)
         {
-            if (InputValues.ContainsKey(CreatureInput))
-            {
-                _InputValues[CreatureInput] = Value;
-            }
-            else
-            {
-                _InputValues.Add(CreatureInput, Value);
-            }
-
+            _InputValues[CreatureInput] = Value;
         }
         public List<Connection> GenerateRandomConnections(int MinConnections, int MaxConnections, double WeightBound)
         {

--- a/MaceEvolve/Models/NeuralNetwork.cs
+++ b/MaceEvolve/Models/NeuralNetwork.cs
@@ -627,14 +627,10 @@ namespace MaceEvolve.Models
             if (NodeId == null)
             {
                 NodeId = NodeIdsToNodesDict.Count;
-                _NodeIdsToNodesDict.Add(NodeId.Value, Node);
-            }
-            else
-            {
-                _NodeIdsToNodesDict[NodeId.Value] = Node;
             }
 
-            _NodesToNodeIdsDict.Add(Node, NodeId.Value);
+            _NodeIdsToNodesDict[NodeId.Value] = Node;
+            _NodesToNodeIdsDict[Node] = NodeId.Value;
 
             return NodeId.Value;
         }
@@ -661,25 +657,21 @@ namespace MaceEvolve.Models
 
             return NodeWasRemoved;
         }
-        public bool RemoveNode(Node Node, bool RemoveConnections)
-        {
-            return RemoveNode(NodesToNodeIdsDict[Node], RemoveConnections);
-        }
-        public void RemoveConnectionsToNode(int NodeIdToRemoveConnectionsFrom)
+        public void RemoveConnectionsToNode(int NodeId)
         {
             foreach (var Connection in Connections)
             {
-                if (Connection.SourceId == NodeIdToRemoveConnectionsFrom || Connection.TargetId == NodeIdToRemoveConnectionsFrom)
+                if (Connection.SourceId == NodeId || Connection.TargetId == NodeId)
                 {
                     Connections.Remove(Connection);
                 }
             }
         }
-        public void RemoveConnectionsToNodes(IEnumerable<int> NodeIdsToRemoveConnectionsFrom)
+        public void RemoveConnectionsToNodes(IEnumerable<int> NodeIds)
         {
             foreach (var Connection in Connections)
             {
-                if (NodeIdsToRemoveConnectionsFrom.Any(x => x == Connection.SourceId || x == Connection.TargetId))
+                if (NodeIds.Any(x => x == Connection.SourceId || x == Connection.TargetId))
                 {
                     Connections.Remove(Connection);
                 }

--- a/MaceEvolve/Models/NeuralNetwork.cs
+++ b/MaceEvolve/Models/NeuralNetwork.cs
@@ -655,7 +655,10 @@ namespace MaceEvolve.Models
         }
         public void RemoveConnectionsToNode(int NodeId)
         {
-            foreach (var Connection in Connections)
+            //Create a new list to prevent an exception caused by trying to modify a collection that is being iterated over.
+            List<Connection> ConnectionsList = Connections.ToList();
+
+            foreach (var Connection in ConnectionsList)
             {
                 if (Connection.SourceId == NodeId || Connection.TargetId == NodeId)
                 {
@@ -665,7 +668,10 @@ namespace MaceEvolve.Models
         }
         public void RemoveConnectionsToNodes(IEnumerable<int> NodeIds)
         {
-            foreach (var Connection in Connections)
+            //Create a new list to prevent an exception caused by trying to modify a collection that is being iterated over.
+            List<Connection> ConnectionsList = Connections.ToList();
+
+            foreach (var Connection in ConnectionsList)
             {
                 if (NodeIds.Any(x => x == Connection.SourceId || x == Connection.TargetId))
                 {

--- a/MaceEvolve/Models/NeuralNetwork.cs
+++ b/MaceEvolve/Models/NeuralNetwork.cs
@@ -613,26 +613,22 @@ namespace MaceEvolve.Models
         }
         public int AddNode(Node Node)
         {
-            int? NodeId = null;
+            bool NodeIdCreated = false;
+            int NodeId = -1;
 
-            foreach (var KeyValuePair in NodeIdsToNodesDict)
+            for (int i = 0; !NodeIdCreated; i++)
             {
-                if (KeyValuePair.Value == null)
+                if (!NodeIdsToNodesDict.ContainsKey(i))
                 {
-                    NodeId = KeyValuePair.Key;
-                    break;
-                }
+                    NodeId = i;
+                    NodeIdCreated = true;
+            }
             }
 
-            if (NodeId == null)
-            {
-                NodeId = NodeIdsToNodesDict.Count;
-            }
+            _NodeIdsToNodesDict[NodeId] = Node;
+            _NodesToNodeIdsDict[Node] = NodeId;
 
-            _NodeIdsToNodesDict[NodeId.Value] = Node;
-            _NodesToNodeIdsDict[Node] = NodeId.Value;
-
-            return NodeId.Value;
+            return NodeId;
         }
         public bool RemoveNode(int NodeId, bool RemoveConnections)
         {
@@ -645,7 +641,7 @@ namespace MaceEvolve.Models
                     RemoveConnectionsToNode(NodeId);
                 }
 
-                _NodeIdsToNodesDict[NodeId] = null;
+                _NodeIdsToNodesDict.Remove(NodeId);
                 _NodesToNodeIdsDict.Remove(Node);
 
                 NodeWasRemoved = true;

--- a/MaceEvolve/Models/Node.cs
+++ b/MaceEvolve/Models/Node.cs
@@ -7,7 +7,7 @@ namespace MaceEvolve.Models
     public class Node
     {
         #region Properties
-        public virtual NodeType NodeType { get; }
+        public NodeType NodeType { get; }
         public double Bias { get; set; }
         public CreatureInput? CreatureInput { get; set; }
         public CreatureAction? CreatureAction { get; set; }

--- a/MaceEvolve/NetworkViewerForm.Designer.cs
+++ b/MaceEvolve/NetworkViewerForm.Designer.cs
@@ -1,0 +1,46 @@
+﻿namespace MaceEvolve
+{
+    partial class NetworkViewerForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // NetworkViewerForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(784, 501);
+            this.Name = "NetworkViewerForm";
+            this.Text = "NetworkViewerForm";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+    }
+}

--- a/MaceEvolve/NetworkViewerForm.cs
+++ b/MaceEvolve/NetworkViewerForm.cs
@@ -1,0 +1,58 @@
+﻿using MaceEvolve.Controls;
+using MaceEvolve.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace MaceEvolve
+{
+    public partial class NetworkViewerForm : Form
+    {
+        #region Fields
+        private NeuralNetworkViewer _NetworkViewer;
+        #endregion
+
+        #region Properties
+        public NeuralNetworkViewer NetworkViewer
+        {
+            get
+            {
+                return _NetworkViewer;
+            }
+            set
+            {
+                if (_NetworkViewer != value && value != null)
+                {
+                    if (_NetworkViewer != null)
+                    {
+                        Controls.Clear();
+                    }
+
+                    _NetworkViewer = value;
+                    Controls.Add(_NetworkViewer);
+                }
+
+            }
+        }
+        #endregion
+
+        #region Constructors
+        public NetworkViewerForm()
+            : this(null)
+        {
+        }
+        public NetworkViewerForm(NeuralNetworkViewer NetworkViewer)
+        {
+            InitializeComponent();
+
+            this.NetworkViewer = NetworkViewer;
+        }
+        #endregion
+    }
+}

--- a/MaceEvolve/NetworkViewerForm.resx
+++ b/MaceEvolve/NetworkViewerForm.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Added a GUI to view a neural network's structure.

Select a creature to view its network.

Press the 'Track Best Creature' button to open another view with a network belonging to the creature that has eaten the most food in the current generation.

* Blue circles are input nodes, grey circles are process nodes, orange circles are output nodes.
* The more negative the connection is, the brighter red it will be. The more positive a connection is, the brighter green it will be.
* The stronger the connection is (how far away is it from 0), the thicker the line is.
* The smaller number at the top of each node is the id. The bigger number is the node's last output value.
* The output node with the highest output value has a thin white border.
* Click a node to select it. The selected node will have a thicker white border. Click and drag on the selected node to move it.

* Optimised reproduction and mutation.
* Added 'RandomInput' CreatureInput.

