### PR TITLE
Reduce dependencies in class `GameObject`

### DIFF
--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -597,12 +597,18 @@ namespace MaceEvolve.Controls
 
             foreach (Creature creature in creaturesList)
             {
-                creature.Draw(e);
+                using (SolidBrush brush = new SolidBrush(creature.Color))
+                {
+                    e.Graphics.FillEllipse(brush, (float)creature.X, (float)creature.Y, (float)creature.Size, (float)creature.Size);
+                }
             }
 
             foreach (Food food in foodList)
             {
-                food.Draw(e);
+                using (SolidBrush brush = new SolidBrush(food.Color))
+                {
+                    e.Graphics.FillEllipse(brush, (float)food.X, (float)food.Y, (float)food.Size, (float)food.Size);
+                }
             }
 
             if (UseSuccessBounds)

--- a/MaceEvolve/Controls/GameHost.cs
+++ b/MaceEvolve/Controls/GameHost.cs
@@ -533,18 +533,21 @@ namespace MaceEvolve.Controls
 
             Food.RemoveAll(x => x.Servings <= 0);
 
-            foreach (Food food in foodList)
-            {
-                food.Update();
-            }
-
             Creature newBestCreature = null;
 
             Point middleOfSuccessBounds = Globals.Middle(SuccessBounds.X, SuccessBounds.Y, SuccessBounds.Width, SuccessBounds.Height);
 
             foreach (Creature creature in creaturesList)
             {
-                creature.Update();
+                if (!creature.IsDead)
+                {
+                    creature.Live();
+
+                    if (creature.Energy < 0)
+                    {
+                        creature.Die();
+                    }
+                }
 
                 if (UseSuccessBounds)
                 {

--- a/MaceEvolve/Models/Creature.cs
+++ b/MaceEvolve/Models/Creature.cs
@@ -81,19 +81,6 @@ namespace MaceEvolve.Models
                     throw new NotImplementedException();
             }
         }
-        public override void Update()
-        {
-            if (!IsDead)
-            {
-                Live();
-
-                if (Energy < 0)
-                {
-                    Die();
-                }
-            }
-
-        }
         public IEnumerable<T> GetVisibleGameObjects<T>(IEnumerable<T> gameObjects) where T : GameObject
         {
             if (typeof(T) == typeof(Creature))

--- a/MaceEvolve/Models/GameObject.cs
+++ b/MaceEvolve/Models/GameObject.cs
@@ -93,13 +93,6 @@ namespace MaceEvolve.Models
         #endregion
 
         #region Methods
-        public virtual void Draw(PaintEventArgs e)
-        {
-            using (SolidBrush Brush = new SolidBrush(Color))
-            {
-                e.Graphics.FillEllipse(Brush, (float)X, (float)Y, (float)Size, (float)Size);
-            }
-        }
         public virtual void Update()
         {
         }

--- a/MaceEvolve/Models/GameObject.cs
+++ b/MaceEvolve/Models/GameObject.cs
@@ -91,11 +91,5 @@ namespace MaceEvolve.Models
         {
         }
         #endregion
-
-        #region Methods
-        public virtual void Update()
-        {
-        }
-        #endregion
     }
 }


### PR DESCRIPTION
`GameObject` should only hold the info about the object and the info needed to draw it. 

Actual drawing of the `GameObject` should be handled externally. 

Likewise, the code for manipulating the state of the `GameObject` in order to represent a concept maintained by something external should also reside in that external object. In this case, the concept would be a simulation, and the external object would be an instance of `GameHost`.